### PR TITLE
Improve Encoding Efficiency with Proper Slice Capacities

### DIFF
--- a/bpe.go
+++ b/bpe.go
@@ -91,16 +91,17 @@ func getMaxStat(stats map[[2]string]int64) [2]string {
 }
 
 func pruneStats(stats, bigStats map[[2]string]int64, threshold float64) {
-	pruntCount := 0
+	var pruneCount int64
 	for item, freq := range stats {
-		if float64(freq) < threshold {
-			delete(stats, item)
-			pruntCount++
-			if freq < 0 {
-				bigStats[item] += freq
-			} else {
-				bigStats[item] = freq
-			}
+		if float64(freq) >= threshold {
+			continue
+		}
+		delete(stats, item)
+		pruneCount++
+		if freq < 0 {
+			bigStats[item] += freq
+		} else {
+			bigStats[item] = freq
 		}
 	}
 }

--- a/encoder.go
+++ b/encoder.go
@@ -287,7 +287,7 @@ func indexOf(wordPieces []string, word string, i int64) int64 {
 func replace(wordPieces []string, bigram [2]string) []string {
 	first, second := bigram[0], bigram[1]
 	pairStr := fmt.Sprintf("%s%s", first, second)
-	newWord := make([]string, 0, len(wordPieces)*2)
+	newWord := make([]string, 0, len(wordPieces))
 	var i int64
 	for i < int64(len(wordPieces)) {
 		j := indexOf(wordPieces, first, i)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -37,6 +37,7 @@ func randomString(n int) string {
 	return string(b)
 }
 func benchmarkEncode(text string, b *testing.B) {
+	b.ReportAllocs()
 	encoder := defaultBenchmarkEncoder(b)
 	for n := 0; n < b.N; n++ {
 		encoder.Encode(text)
@@ -131,6 +132,7 @@ func generateTokens(numTokens int) []int64 {
 }
 
 func benchmarkTokenDecode(numTokens int, b *testing.B) {
+	b.ReportAllocs()
 	encoder := defaultBenchmarkEncoder(b)
 	tokens := generateTokens(numTokens)
 	s := encoder.Decode(tokens)
@@ -142,6 +144,7 @@ func benchmarkTokenDecode(numTokens int, b *testing.B) {
 }
 
 func benchmarkDecode(numTokens int, b *testing.B) {
+	b.ReportAllocs()
 	encoder := defaultBenchmarkEncoder(b)
 	tokens := generateTokens(numTokens)
 


### PR DESCRIPTION
We've been investigating different native Go BPE tokenizers and saw a few places where this library could be sped up. Really tiny optimizations overall, nothing clever. Turns out pre-allocation helps quite a bit. Eliminating the redundant map accesses in `getMinPair` also helped. `(6835714-4503505)/6835714 ≈ 34%` improvement on `Benchmark1000TokensEncode`. Not sure if this is the tokenizer you all are using in online endpoints but thought it couldn't hurt to push the changes.

**Pre**-Change:
```
goos: darwin
goarch: arm64
pkg: github.com/cohere-ai/tokenizer
BenchmarkEncode1Sentence-10     	   18987	     62804 ns/op	   38934 B/op	     705 allocs/op
BenchmarkEncode1Paragraph-10    	    2823	    373283 ns/op	  218765 B/op	    3892 allocs/op
BenchmarkEncode1KB-10           	    1684	    643150 ns/op	  372619 B/op	    6528 allocs/op
BenchmarkEncode1MB-10           	       2	 661916729 ns/op	404627168 B/op	 6571443 allocs/op
Benchmark1000TokensDecode-10    	    7273	    150288 ns/op	   25008 B/op	       9 allocs/op
Benchmark1000TokensEncode-10    	     174	   6835714 ns/op	 4390021 B/op	   49710 allocs/op
PASS
ok  	github.com/cohere-ai/tokenizer	15.559s
```

**Post**-Change:
```
goos: darwin
goarch: arm64
pkg: github.com/cohere-ai/tokenizer
BenchmarkEncode1Sentence-10     	   21070	     57748 ns/op	   35158 B/op	     656 allocs/op
BenchmarkEncode1Paragraph-10    	    3217	    333311 ns/op	  201084 B/op	    3619 allocs/op
BenchmarkEncode1KB-10           	    1958	    562453 ns/op	  339983 B/op	    6000 allocs/op
BenchmarkEncode1MB-10           	       2	 588600562 ns/op	358751276 B/op	 6160235 allocs/op
Benchmark1000TokensDecode-10    	    8214	    131448 ns/op	   25008 B/op	       9 allocs/op
Benchmark1000TokensEncode-10    	     260	   4503505 ns/op	 2937334 B/op	   30454 allocs/op
PASS
ok  	github.com/cohere-ai/tokenizer	15.243s
```