### PR TITLE
Return string representation of tokens

### DIFF
--- a/bpe_test.go
+++ b/bpe_test.go
@@ -127,7 +127,7 @@ func testBPEEncode(t *testing.T) {
 		}
 
 		for i, text := range texts {
-			tokens := encoder.Encode(text)
+			tokens, _ := encoder.Encode(text)
 			if len(test.expectedTokens[i]) != len(tokens) {
 				t.Fatalf("expected %d tokens but only got %d for \"%s\"", len(test.expectedTokens[i]), len(tokens), text)
 			}

--- a/encoder.go
+++ b/encoder.go
@@ -324,6 +324,11 @@ func (e *Encoder) Encode(text string) []int64 {
 	return e.EncodeWords(words)
 }
 
+func (e *Encoder) EncodeV2(text string) ([]int64, []string) {
+	words := WordSplit(text)
+	return e.EncodeWords(words), words
+}
+
 func (e *Encoder) Decode(tokens []int64) string {
 	var decodeBuffer bytes.Buffer
 	for _, token := range tokens {

--- a/encoder.go
+++ b/encoder.go
@@ -318,12 +318,7 @@ func replace(wordPieces []string, bigram [2]string) []string {
 	return newWord
 }
 
-func (e *Encoder) Encode(text string) []int64 {
-	words := WordSplit(text)
-	return e.EncodeWords(words)
-}
-
-func (e *Encoder) EncodeV2(text string) ([]int64, []string) {
+func (e *Encoder) Encode(text string) ([]int64, []string) {
 	words := WordSplit(text)
 	return e.EncodeWords(words), words
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -107,7 +107,7 @@ func TestEncodeDecodeSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testCase.Name, func(tt *testing.T) {
 			joinedTokens := strings.Join(tc.tokens, "")
-			encoded := encoder.Encode(joinedTokens)
+			encoded, _ := encoder.Encode(joinedTokens)
 
 			require.Len(t, encoded, len(tc.tokens))
 			for i, token := range tc.tokens {
@@ -174,11 +174,4 @@ func TestFromPrebuiltAndFromReader(t *testing.T) {
 		t.Logf("The encoders are not the same.")
 		t.Fail()
 	}
-}
-
-func TestEncodeV2(t *testing.T) {
-	e := defaultEncoder(t)
-	tokenIds, tokenStrings := e.EncodeV2("hello world")
-	require.Equal(t, len(tokenIds), len(tokenStrings), "The number of tokens should be the same")
-	require.Equal(t, e.Encode("hello world"), tokenIds, "Output of EncodeV2 should be the same as Encode")
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -175,3 +175,10 @@ func TestFromPrebuiltAndFromReader(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestEncodeV2(t *testing.T) {
+	e := defaultEncoder(t)
+	tokenIds, tokenStrings := e.EncodeV2("hello world")
+	require.Equal(t, len(tokenIds), len(tokenStrings), "The number of tokens should be the same")
+	require.Equal(t, e.Encode("hello world"), tokenIds, "Output of EncodeV2 should be the same as Encode")
+}


### PR DESCRIPTION
This PR adds a new `EncodeV2` method to the encoder. It behaves exactly like the old encode function, but in addition to returning a list of Token IDs, it also returns a list of the Token string representations.

Usecase:

```
tokenIDs, tokenStrings = encoder.Encode('hello there')
```