### PR TITLE
Bump version of golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,5 +11,5 @@ jobs:
         uses: golangci/golangci-lint-action@v2.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.48
           args: --timeout=3m0s

--- a/encoder.go
+++ b/encoder.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/dlclark/regexp2"
@@ -47,7 +46,7 @@ func NewFromReaders(encoderReader, vocabReader io.Reader) (*Encoder, error) {
 		bpeMerges = append(bpeMerges, [2]string{split[0], split[1]})
 	}
 
-	encoderContents, err := ioutil.ReadAll(encoderReader)
+	encoderContents, err := io.ReadAll(encoderReader)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read encoder file")
 	}


### PR DESCRIPTION
Linter CI has been failing. Updated version of golangci-lint (and removed a deprecated package) to fix.