### PR TITLE
Fix string representation return

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -107,14 +107,14 @@ func TestEncodeDecodeSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testCase.Name, func(tt *testing.T) {
 			joinedTokens := strings.Join(tc.tokens, "")
-			encoded, _ := encoder.Encode(joinedTokens)
+			tokenIDs, tokenStrings := encoder.Encode(joinedTokens)
 
-			require.Len(t, encoded, len(tc.tokens))
 			for i, token := range tc.tokens {
-				require.Equal(t, token, encoder.Decode([]int64{encoded[i]}))
+				require.Equal(t, token, encoder.Decode([]int64{tokenIDs[i]}))
+				require.Equal(t, token, tokenStrings[i])
 			}
 
-			require.Equal(t, joinedTokens, encoder.Decode(encoded))
+			require.Equal(t, joinedTokens, encoder.Decode(tokenIDs))
 		})
 	}
 }


### PR DESCRIPTION
In a previous PR (https://github.com/cohere-ai/tokenizer/pull/34) the Encode function was changed to return the string representation of tokens too. The logic was broken though - it returned the words, not the tokens, which are not always the same.

This PR fixes that issue.